### PR TITLE
Correct features to avoid ring if desired.

### DIFF
--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -13,13 +13,11 @@ categories = ["network-programming", "web-programming"]
 
 [features]
 default = ["aws-lc-rs"]
-aws-lc-rs = ["dep:aws-lc-rs", "quinn/rustls-aws-lc-rs", "rustls/aws-lc-rs"]
-ring = ["dep:ring", "quinn/rustls-ring", "rustls/ring"]
+aws-lc-rs = ["quinn/rustls-aws-lc-rs", "rustls/aws-lc-rs"]
+ring = ["quinn/rustls-ring", "rustls/ring"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-lc-rs = { version = "1", optional = true }
-
 bytes = "1"
 futures = "0.3"
 http = "1"
@@ -30,7 +28,6 @@ quinn = { version = "0.11", default-features = false, features = [
     "runtime-tokio",
     "bloom",
 ] }
-ring = { version = "0.17.13", optional = true }
 
 rustls = { version = "0.23", default-features = false, features = [
     "logging",

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["network-programming", "web-programming"]
 
 [features]
 default = ["aws-lc-rs"]
-aws-lc-rs = ["dep:aws-lc-rs", "quinn/aws-lc-rs", "rustls/aws-lc-rs"]
-ring = ["dep:ring", "quinn/ring", "rustls/ring"]
+aws-lc-rs = ["dep:aws-lc-rs", "quinn/rustls-aws-lc-rs", "rustls/aws-lc-rs"]
+ring = ["dep:ring", "quinn/rustls-ring", "rustls/ring"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -25,8 +25,11 @@ futures = "0.3"
 http = "1"
 log = "0.4"
 
-quinn = "0.11"
-quinn-proto = "0.11"
+quinn = { version = "0.11", default-features = false, features = [
+    "platform-verifier",
+    "runtime-tokio",
+    "bloom",
+] }
 ring = { version = "0.17.13", optional = true }
 
 rustls = { version = "0.23", default-features = false, features = [

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -52,7 +52,6 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
 quinn = "0.11"
-quinn-proto = "0.11"
 rustls = "0.23"
 rustls-pemfile = "2"
 tokio = { version = "1", features = ["full"] }

--- a/web-transport-quinn/Cargo.toml
+++ b/web-transport-quinn/Cargo.toml
@@ -51,7 +51,5 @@ web-transport-trait = { path = "../web-transport-trait", version = "0.1" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-quinn = "0.11"
-rustls = "0.23"
 rustls-pemfile = "2"
 tokio = { version = "1", features = ["full"] }

--- a/web-transport-quinn/examples/echo-client-advanced.rs
+++ b/web-transport-quinn/examples/echo-client-advanced.rs
@@ -39,9 +39,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Standard quinn setup, accepting only the given certificate.
     // You should use system roots in production.
-    let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(
-        rustls::crypto::aws_lc_rs::default_provider(),
-    ))
+    let mut config = rustls::ClientConfig::builder_with_provider(
+        web_transport_quinn::crypto::default_provider(),
+    )
     .with_protocol_versions(&[&rustls::version::TLS13])?
     .with_root_certificates(roots)
     .with_no_client_auth();

--- a/web-transport-quinn/examples/echo-server-advanced.rs
+++ b/web-transport-quinn/examples/echo-server-advanced.rs
@@ -58,9 +58,9 @@ async fn main() -> anyhow::Result<()> {
         .context("missing private key")?;
 
     // Standard Quinn setup
-    let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
-        rustls::crypto::ring::default_provider(),
-    ))
+    let mut config = rustls::ServerConfig::builder_with_provider(
+        web_transport_quinn::crypto::default_provider(),
+    )
     .with_protocol_versions(&[&rustls::version::TLS13])?
     .with_no_client_auth()
     .with_single_cert(chain, key)?;

--- a/web-transport-quinn/src/crypto.rs
+++ b/web-transport-quinn/src/crypto.rs
@@ -41,16 +41,5 @@ pub fn sha256(provider: &Provider, cert: &CertificateDer<'_>) -> hash::Output {
         return hash_provider.hash(cert);
     }
 
-    #[cfg(feature = "aws-lc-rs")]
-    {
-        hash::Output::new(aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, cert).as_ref())
-    }
-    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
-    {
-        return hash::Output::new(ring::digest::digest(&ring::digest::SHA256, cert).as_ref());
-    }
-    #[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
-    {
-        panic!("No SHA-256 backend available. Ensure your provider exposes SHA-256 or enable 'ring'/'aws-lc-rs' feature.");
-    }
+    panic!("No SHA-256 backend available. Ensure your provider exposes SHA-256 or enable the 'ring'/'aws-lc-rs' feature.");
 }

--- a/web-transport-quinn/src/crypto.rs
+++ b/web-transport-quinn/src/crypto.rs
@@ -12,17 +12,19 @@ pub fn default_provider() -> Provider {
         return provider;
     }
 
-    #[cfg(feature = "aws-lc-rs")]
+    #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
     {
-        Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+        return Arc::new(rustls::crypto::aws_lc_rs::default_provider());
     }
     #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
     {
-        Arc::new(rustls::crypto::ring::default_provider())
+        return Arc::new(rustls::crypto::ring::default_provider());
     }
-    #[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
+    #[allow(unreachable_code)]
     {
-        panic!("rustls CryptoProvider::set_default() not called and no 'ring'/'aws-lc-rs' feature enabled.");
+        panic!(
+        "CryptoProvider::set_default() must be called; or only enable one ring/aws-lc-rs feature."
+    );
     }
 }
 

--- a/web-transport-quinn/src/lib.rs
+++ b/web-transport-quinn/src/lib.rs
@@ -25,7 +25,6 @@
 
 // External
 mod client;
-pub(crate) mod crypto;
 mod error;
 mod recv;
 mod send;
@@ -48,6 +47,9 @@ use settings::*;
 
 /// The HTTP/3 ALPN is required when negotiating a QUIC connection.
 pub const ALPN: &str = "h3";
+
+/// Export our simple crypto provider.
+pub mod crypto;
 
 /// Re-export the underlying QUIC implementation.
 pub use quinn;

--- a/web-transport-quinn/src/send.rs
+++ b/web-transport-quinn/src/send.rs
@@ -56,10 +56,7 @@ impl SendStream {
     }
 
     /// Write chunks of data to the stream. See [`quinn::SendStream::write_chunks`].
-    pub async fn write_chunks(
-        &mut self,
-        bufs: &mut [Bytes],
-    ) -> Result<quinn_proto::Written, WriteError> {
+    pub async fn write_chunks(&mut self, bufs: &mut [Bytes]) -> Result<quinn::Written, WriteError> {
         self.stream.write_chunks(bufs).await.map_err(Into::into)
     }
 


### PR DESCRIPTION
quinn-proto isn't required either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable TLS backend options (aws-lc or ring) and made the ring backend optional for more flexible platform support.

- Chores
  - Switched QUIC dependency to a feature-gated configuration (runtime, platform verifier, bloom) and removed an internal QUIC proto dependency to streamline footprints.

- Refactor
  - Adjusted stream write result handling to align with the updated QUIC/rustls integration; no change to user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->